### PR TITLE
Add daily-local to API v1

### DIFF
--- a/app/Http/Controllers/API/V1/SiteController.php
+++ b/app/Http/Controllers/API/V1/SiteController.php
@@ -180,14 +180,14 @@ class SiteController extends Controller
     /**
      * Get the daily summaries for a specific site.
      */
-    public function daily(Request $request, Site $site): JsonResponse
+    public function daily(Request $request, Site $site, bool $local = false): JsonResponse
     {
         $validated = $request->validate([
             'day1' => ['date_format:Y-m-d\\TH:i:s.vp'],
             'day2' => ['date_format:Y-m-d\\TH:i:s.vp'],
         ]);
 
-        $dailySummaries = $site->dayAggregate();
+        $dailySummaries = $local === true ? $site->dayAggregateLocal() : $site->dayAggregate();
 
         if (isset($validated['day1'], $validated['day2'])) {
             $dailySummaries
@@ -238,5 +238,18 @@ class SiteController extends Controller
             ]);
 
         return response()->json($result);
+    }
+
+    /**
+     * Get the daily summaries in local time for a specific site.
+     */
+    public function dailyLocal(Request $request, Site $site): JsonResponse
+    {
+        $request->validate([
+            'day1' => ['date_format:Y-m-d\\TH:i:s.vp'],
+            'day2' => ['date_format:Y-m-d\\TH:i:s.vp'],
+        ]);
+
+        return $this->daily($request, $site, true);
     }
 }

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -155,4 +155,14 @@ class Site extends Model implements HasMedia
     {
         return $this->hasMany(DayAggregate::class, 'site_id', 'id'); // @phpstan-ignore return.type
     }
+
+    /**
+     * Get the observations aggregate per day for the site in local time.
+     *
+     * @return HasMany<DayAggregate,self>
+     */
+    public function dayAggregateLocal(): HasMany
+    {
+        return $this->hasMany(DayAggregateLocal::class, 'site_id', 'id'); // @phpstan-ignore return.type
+    }
 }

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -159,7 +159,7 @@ class Site extends Model implements HasMedia
     /**
      * Get the observations aggregate per day for the site in local time.
      *
-     * @return HasMany<DayAggregate,self>
+     * @return HasMany<DayAggregateLocal,self>
      */
     public function dayAggregateLocal(): HasMany
     {

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -22,6 +22,7 @@ Route::prefix('site')
                 Route::get('', 'show');
                 Route::get('latest', 'latest');
                 Route::get('daily', 'daily');
+                Route::get('daily-local', 'dailyLocal');
                 Route::get('graph', 'graph');
             });
     });


### PR DESCRIPTION
> [!note]
> This wasn't part of the initial WOW API so this is not part of the backwards compatibility with the old WOW API.
> This feature has been added to fix an issue in the existing IRM/KMI frontend: https://wow.meteo.be/

This add a new endpoint to have a daily summary of the measurements for a specific site.
Daily summary is specified using UTC, this new `daily-local` endpoint makes the daily summary (00:00-23:59) based on the local time instead of UTC.

Close #179 